### PR TITLE
Fix Anthropic JSON parsing

### DIFF
--- a/tests/test_call_llm.py
+++ b/tests/test_call_llm.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import types
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'CODE')))
+
+sys.modules.setdefault('PyPDF2', types.SimpleNamespace(PdfReader=None))
+sys.modules.setdefault('docx', types.SimpleNamespace(Document=None))
+
+from base_analyzer import BaseAnalyzer
+from config import GlobalConfig, LLMConfig, ReviewMode
+
+class DummyAnalyzer(BaseAnalyzer):
+    def create_analysis_prompt(self, document_content: str, framework_chunk: dict) -> str:
+        return ""
+
+    def get_system_message(self) -> str:
+        return ""
+
+def test_call_llm_parses_anthropic_response(monkeypatch):
+    cfg = GlobalConfig(
+        review_mode=ReviewMode.REGULATION,
+        llm_configs={},
+        input_path="",
+        output_path="",
+    )
+    analyzer = DummyAnalyzer(cfg)
+    llm = LLMConfig(provider="anthropic", api_key="key", model="model")
+
+    def fake_call(self, llm_config, system_msg, user_msg):
+        return "```json\n{\"ok\": true}\n```"
+
+    monkeypatch.setattr(BaseAnalyzer, "_call_anthropic", fake_call)
+    result = analyzer.call_llm(llm, "sys", "user")
+    assert result == {"ok": True}


### PR DESCRIPTION
## Summary
- handle Anthropic JSON formatting
- enforce json output when calling Anthropic API
- test parsing of typical Anthropic response

## Testing
- `pytest -q`