### PR TITLE
Enable regulation name in heatmap output

### DIFF
--- a/CODE/VISUAL/heatmap_generator.py
+++ b/CODE/VISUAL/heatmap_generator.py
@@ -8,7 +8,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 import matplotlib.font_manager as fm
 
 # 设置中文字体
@@ -201,8 +201,14 @@ class ComplianceHeatmapGenerator:
                             break
         
         return score_matrix
+
+    def get_regulation_name(self, json_path: str) -> str:
+        """根据文件路径推断法规名称"""
+        name = Path(json_path).stem
+        name = name.replace("综合分析结果", "").replace("分析结果", "").rstrip("_")
+        return name
     
-    def create_heatmap(self, score_matrix: pd.DataFrame, output_path: str = None):
+    def create_heatmap(self, score_matrix: pd.DataFrame, output_path: str = None, regulation_name: Optional[str] = None):
         """
         创建热力图
         
@@ -231,8 +237,10 @@ class ComplianceHeatmapGenerator:
         )
         
         # 设置标题
-        ax.set_title('\n法规合规覆盖热力图', 
-                     fontsize=16, pad=20)
+        title = '\n法规合规覆盖热力图'
+        if regulation_name:
+            title = f"{regulation_name}\n法规合规覆盖热力图"
+        ax.set_title(title, fontsize=16, pad=20)
         ax.set_xlabel('制度评审专家', fontsize=12)
         ax.set_ylabel('风险梳理框架', fontsize=12)
         
@@ -265,7 +273,7 @@ class ComplianceHeatmapGenerator:
         
         plt.close()
     
-    def create_category_summary_heatmap(self, score_matrix: pd.DataFrame, output_path: str = None):
+    def create_category_summary_heatmap(self, score_matrix: pd.DataFrame, output_path: str = None, regulation_name: Optional[str] = None):
         """
         创建按类别汇总的热力图
         
@@ -308,9 +316,10 @@ class ComplianceHeatmapGenerator:
             linecolor='white'
         )
         
-        # 设置标题
-        ax.set_title('Regulatory Compliance Coverage by Category\n法规合规覆盖分类汇总', 
-                     fontsize=16, pad=20)
+        title = 'Regulatory Compliance Coverage by Category\n法规合规覆盖分类汇总'
+        if regulation_name:
+            title = f"{regulation_name}\n" + title
+        ax.set_title(title, fontsize=16, pad=20)
         ax.set_xlabel('LLM Providers', fontsize=12)
         ax.set_ylabel('Compliance Categories', fontsize=12)
         
@@ -330,7 +339,7 @@ class ComplianceHeatmapGenerator:
         
         plt.close()
     
-    def generate_analysis_report(self, score_matrix: pd.DataFrame, output_path: str = None):
+    def generate_analysis_report(self, score_matrix: pd.DataFrame, output_path: str = None, regulation_name: Optional[str] = None):
         """
         生成分析报告
         
@@ -340,7 +349,10 @@ class ComplianceHeatmapGenerator:
         """
         report = []
         report.append("=" * 80)
-        report.append("法规合规覆盖分析报告")
+        header = "法规合规覆盖分析报告"
+        if regulation_name:
+            header = f"{regulation_name} {header}"
+        report.append(header)
         report.append("=" * 80)
         report.append("")
         
@@ -436,6 +448,7 @@ def main():
     
     # 处理JSON数据
     json_path = "Result/regulation_20250524_112352/关于进一步引导和规范境外投资方向指导意见_综合分析结果.json"
+    regulation_name = generator.get_regulation_name(json_path)
     
     try:
         # 生成得分矩阵
@@ -444,23 +457,27 @@ def main():
         
         # 生成详细热力图
         print("正在生成详细热力图...")
+        safe_name = regulation_name.replace('/', '_')
         generator.create_heatmap(
-            score_matrix, 
-            output_path="compliance_heatmap_detailed.png"
+            score_matrix,
+            output_path=f"{safe_name}_详细热力图.png",
+            regulation_name=regulation_name
         )
         
         # 生成类别汇总热力图
         print("正在生成类别汇总热力图...")
         generator.create_category_summary_heatmap(
             score_matrix,
-            output_path="compliance_heatmap_category.png"
+            output_path=f"{safe_name}_分类汇总热力图.png",
+            regulation_name=regulation_name
         )
         
         # 生成分析报告
         print("正在生成分析报告...")
         generator.generate_analysis_report(
             score_matrix,
-            output_path="compliance_analysis_report.txt"
+            output_path=f"{safe_name}_分析报告.txt",
+            regulation_name=regulation_name
         )
         
         print("\n所有文件已生成完成！")

--- a/CODE/VISUAL/heatmap_summary.md
+++ b/CODE/VISUAL/heatmap_summary.md
@@ -34,9 +34,9 @@ python instant_heatmap.py
 | 文件名 | 内容 | 用途 |
 |--------|------|------|
 | instant_heatmap.png | 35×3基础热力图 | 快速查看 |
-| compliance_heatmap_detailed.png | 详细热力图 | 深入分析 |
-| compliance_heatmap_category.png | 类别汇总图 | 管理层汇报 |
-| compliance_analysis_report.txt | 文字报告 | 详细说明 |
+| <法规名称>_详细热力图.png | 详细热力图 | 深入分析 |
+| <法规名称>_分类汇总热力图.png | 类别汇总图 | 管理层汇报 |
+| <法规名称>_分析报告.txt | 文字报告 | 详细说明 |
 | compliance_analysis.xlsx | Excel数据 | 进一步分析 |
 
 ## 评分机制说明

--- a/CODE/VISUAL/heatmap_usage_guide.md
+++ b/CODE/VISUAL/heatmap_usage_guide.md
@@ -48,15 +48,16 @@ generator = ComplianceHeatmapGenerator()
 
 # 处理数据
 score_matrix = generator.process_json_data("your_file.json")
+reg_name = generator.get_regulation_name("your_file.json")
 
 # 生成详细热力图
-generator.create_heatmap(score_matrix, "detailed_heatmap.png")
+generator.create_heatmap(score_matrix, "详细热力图.png", regulation_name=reg_name)
 
 # 生成类别汇总
-generator.create_category_summary_heatmap(score_matrix, "category_heatmap.png")
+generator.create_category_summary_heatmap(score_matrix, "分类汇总热力图.png", regulation_name=reg_name)
 
 # 生成报告
-generator.generate_analysis_report(score_matrix, "report.txt")
+generator.generate_analysis_report(score_matrix, "report.txt", regulation_name=reg_name)
 ```
 
 ## 热力图解读
@@ -81,15 +82,15 @@ generator.generate_analysis_report(score_matrix, "report.txt")
 
 ## 输出文件说明
 
-1. **compliance_heatmap_detailed.png**
+1. **<法规名称>_详细热力图.png**
    - 35个要求的详细热力图
    - 显示每个要求在各LLM中的具体得分
 
-2. **compliance_heatmap_category.png**
+2. **<法规名称>_分类汇总热力图.png**
    - 8个大类的汇总热力图
    - 显示每个类别的平均得分
 
-3. **compliance_analysis_report.txt**
+3. **<法规名称>_分析报告.txt**
    - 文字版分析报告
    - 包含统计数据和重点发现
 

--- a/CODE/VISUAL/run_heatmap_sh.sh
+++ b/CODE/VISUAL/run_heatmap_sh.sh
@@ -77,11 +77,13 @@ try:
     
     generator = ComplianceHeatmapGenerator()
     score_matrix = generator.process_json_data("$json_file")
+    reg_name = generator.get_regulation_name("$json_file")
+    safe_name = reg_name.replace('/', '_')
     
     # 生成所有图表
-    generator.create_heatmap(score_matrix, "$output_dir/detailed_heatmap.png")
-    generator.create_category_summary_heatmap(score_matrix, "$output_dir/category_heatmap.png")
-    generator.generate_analysis_report(score_matrix, "$output_dir/analysis_report.txt")
+    generator.create_heatmap(score_matrix, f"$output_dir/{safe_name}_详细热力图.png", regulation_name=reg_name)
+    generator.create_category_summary_heatmap(score_matrix, f"$output_dir/{safe_name}_分类汇总热力图.png", regulation_name=reg_name)
+    generator.generate_analysis_report(score_matrix, f"$output_dir/{safe_name}_分析报告.txt", regulation_name=reg_name)
     
 except ImportError:
     print("使用简化版生成器...")


### PR DESCRIPTION
## Summary
- add `get_regulation_name` helper to extract the regulation title
- use regulation name in heatmap titles and output filenames
- update batch script and docs for the new naming scheme

## Testing
- `python -m py_compile CODE/VISUAL/heatmap_generator.py`